### PR TITLE
Argo maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ language: objective-c
 # podfile: Example/Podfile
 before_install:
 - gem install cocoapods # Since Travis is not always on latest version
+- rm -rf Example/Pods
 - pod install --project-directory=Example --repo-update
 script:
 - set -o pipefail && xcodebuild test -workspace Example/ACKReactiveExtensions.xcworkspace -scheme ACKReactiveExtensions-Example -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.1' ONLY_ACTIVE_ARCH=NO | xcpretty
-- travis_wait 120 pod lib lint --allow-warnings
+#- travis_wait 120 pod lib lint --allow-warnings

--- a/ACKReactiveExtensions/Argo/ArgoDeprecations.swift
+++ b/ACKReactiveExtensions/Argo/ArgoDeprecations.swift
@@ -9,6 +9,7 @@
 import Foundation
 import ReactiveSwift
 import Argo
+import Result
 
 /**
  * Reactively decode an object
@@ -131,5 +132,52 @@ public func rac_decodeByOne < T: Decodable where T == T.DecodedType > (object: A
             sink.send(error: e)
             break
         }
+    }
+}
+
+
+extension SignalProtocol where Value == Any, Error: DecodeErrorCreatable {
+    
+    /**
+     * Map value as `Decodable` object
+     *
+     * - parameter key: If your objects are contained within dictionary pass the key here
+     */
+    @available(*, renamed: "mapResponse(forKey:)")
+    public func mapResponseArgo<ResultType: Decodable>(for key: String? = nil) -> Signal<ResultType, Error> where ResultType.DecodedType == ResultType {
+        return mapResponse(forKey: key)
+    }
+    
+    /**
+     * Map values as `Decodable` objects
+     *
+     * - parameter key: If your objects are contained within dictionary pass the key here
+     */
+    @available(*, renamed: "mapResponse(forKey:)")
+    public func mapResponseArgo<ResultType: Decodable>(for key: String? = nil) -> Signal<[ResultType], Error> where ResultType.DecodedType == ResultType {
+        return mapResponse(forKey: key)
+    }
+}
+
+extension SignalProducerProtocol where Value == Any, Error: DecodeErrorCreatable {
+    
+    /**
+     * Map value as `Decodable` object
+     *
+     * - parameter key: If your objects are contained within dictionary pass the key here
+     */
+    @available(*, renamed: "mapResponse(forKey:)")
+    public func mapResponseArgo<ResultType: Decodable>(for key: String? = nil) -> SignalProducer<ResultType, Error> where ResultType.DecodedType == ResultType {
+        return lift { $0.mapResponseArgo(for: key) }
+    }
+    
+    /**
+     * Map values as `Decodable` objects
+     *
+     * - parameter key: If your objects are contained within dictionary pass the key here
+     */
+    @available(*, renamed: "mapResponse(forKey:)")
+    public func mapResponseArgo<ResultType: Decodable>(for key: String? = nil) -> SignalProducer<[ResultType], Error> where ResultType.DecodedType == ResultType {
+        return lift { $0.mapResponseArgo(for: key) }
     }
 }

--- a/ACKReactiveExtensions/Argo/ArgoDeprecations.swift
+++ b/ACKReactiveExtensions/Argo/ArgoDeprecations.swift
@@ -18,7 +18,7 @@ import Result
  * - returns: SignalProducer that sends decoded object
  */
 @available(*, deprecated, message: "Use extension mapResponseArgo() on SignalProducer<Any,DecodeErrorCreatable>")
-public func rac_decode < T: Decodable where T == T.DecodedType > (object: AnyObject) -> SignalProducer<T, DecodeError> {
+public func rac_decode < T: Decodable> (object: AnyObject) -> SignalProducer<T, DecodeError> where T == T.DecodedType  {
     return SignalProducer { sink, disposable in
         
         let decoded: Decoded<T> = decode(object)
@@ -39,7 +39,7 @@ public func rac_decode < T: Decodable where T == T.DecodedType > (object: AnyObj
  * - returns: SignalProducer that sends decoded array
  */
 @available(*, deprecated, message: "Use extension mapResponseArgo() on SignalProducer<Any,DecodeErrorCreatable>")
-public func rac_decode < T: Decodable where T == T.DecodedType > (object: AnyObject) -> SignalProducer<[T], DecodeError> {
+public func rac_decode < T: Decodable> (object: AnyObject) -> SignalProducer<[T], DecodeError> where T == T.DecodedType  {
     return SignalProducer { sink, disposable in
         
         let decoded: Decoded<[T]> = decode(object)
@@ -62,7 +62,7 @@ public func rac_decode < T: Decodable where T == T.DecodedType > (object: AnyObj
  * - returns: SignalProducer that sends decoded array
  */
 @available(*, deprecated, message: "Use extension mapResponseArgo() on SignalProducer<Any,DecodeErrorCreatable>")
-public func rac_decodeWithRootKey < T: Decodable where T == T.DecodedType > (rootKey: String, object: AnyObject) -> SignalProducer<[T], DecodeError> {
+public func rac_decodeWithRootKey < T: Decodable> (rootKey: String, object: AnyObject) -> SignalProducer<[T], DecodeError> where T == T.DecodedType  {
     return SignalProducer { sink, disposable in
         
         guard let object = object as? [String: AnyObject] else {
@@ -90,7 +90,7 @@ public func rac_decodeWithRootKey < T: Decodable where T == T.DecodedType > (roo
  * - returns: SignalProducer that sends decoded object
  */
 @available(*, deprecated, message: "Use extension mapResponseArgo() on SignalProducer<Any,DecodeErrorCreatable>")
-public func rac_decodeWithRootKey < T: Decodable where T == T.DecodedType > (rootKey: String, object: AnyObject) -> SignalProducer<T, DecodeError> {
+public func rac_decodeWithRootKey < T: Decodable> (rootKey: String, object: AnyObject) -> SignalProducer<T, DecodeError> where T == T.DecodedType  {
     return SignalProducer { sink, disposable in
         
         guard let object = object as? [String: AnyObject] else {
@@ -118,7 +118,7 @@ public func rac_decodeWithRootKey < T: Decodable where T == T.DecodedType > (roo
  * - returns: SignalProducer that sends decoded array one by one
  */
 @available(*, deprecated, message: "Use extension mapResponseArgo() on SignalProducer<Any,DecodeErrorCreatable>")
-public func rac_decodeByOne < T: Decodable where T == T.DecodedType > (object: AnyObject) -> SignalProducer<T, DecodeError> {
+public func rac_decodeByOne < T: Decodable> (object: AnyObject) -> SignalProducer<T, DecodeError> where T == T.DecodedType  {
     return SignalProducer { sink, disposable in
         
         let decoded: Decoded<[T]> = decode(object)

--- a/ACKReactiveExtensions/Argo/ArgoMapping.swift
+++ b/ACKReactiveExtensions/Argo/ArgoMapping.swift
@@ -36,7 +36,7 @@ extension SignalProtocol where Value == Any, Error: DecodeErrorCreatable {
      *
      * - parameter key: If your objects are contained within dictionary pass the key here
      */
-    public func mapResponseArgo<ResultType: Decodable>(for key: String? = nil) -> Signal<ResultType, Error> where ResultType.DecodedType == ResultType {
+    public func mapResponse<ResultType: Decodable>(for key: String? = nil) -> Signal<ResultType, Error> where ResultType.DecodedType == ResultType {
         return attemptMap { data in
             let decoded: Decoded<ResultType> = key.map {
             let dict = data as? [String: Any] ?? [:]
@@ -57,7 +57,7 @@ extension SignalProtocol where Value == Any, Error: DecodeErrorCreatable {
      *
      * - parameter key: If your objects are contained within dictionary pass the key here
      */
-    public func mapResponseArgo<ResultType: Decodable>(for key: String? = nil) -> Signal<[ResultType], Error> where ResultType.DecodedType == ResultType {
+    public func mapResponse<ResultType: Decodable>(for key: String? = nil) -> Signal<[ResultType], Error> where ResultType.DecodedType == ResultType {
         return attemptMap { data in
             let decoded: Decoded<[ResultType]> = key.map {
                 let dict = data as? [String: Any] ?? [:]
@@ -81,8 +81,8 @@ extension SignalProducerProtocol where Value == Any, Error: DecodeErrorCreatable
      *
      * - parameter key: If your objects are contained within dictionary pass the key here
      */
-    public func mapResponseArgo<ResultType: Decodable>(for key: String? = nil) -> SignalProducer<ResultType, Error> where ResultType.DecodedType == ResultType {
-        return lift { $0.mapResponseArgo(for: key) }
+    public func mapResponse<ResultType: Decodable>(for key: String? = nil) -> SignalProducer<ResultType, Error> where ResultType.DecodedType == ResultType {
+        return lift { $0.mapResponse(for: key) }
     }
     
     /**
@@ -90,7 +90,7 @@ extension SignalProducerProtocol where Value == Any, Error: DecodeErrorCreatable
      *
      * - parameter key: If your objects are contained within dictionary pass the key here
      */
-    public func mapResponseArgo<ResultType: Decodable>(for key: String? = nil) -> SignalProducer<[ResultType], Error> where ResultType.DecodedType == ResultType {
-        return lift { $0.mapResponseArgo(for: key) }
+    public func mapResponse<ResultType: Decodable>(for key: String? = nil) -> SignalProducer<[ResultType], Error> where ResultType.DecodedType == ResultType {
+        return lift { $0.mapResponse(for: key) }
     }
 }

--- a/ACKReactiveExtensions/Argo/ArgoMapping.swift
+++ b/ACKReactiveExtensions/Argo/ArgoMapping.swift
@@ -36,7 +36,7 @@ extension SignalProtocol where Value == Any, Error: DecodeErrorCreatable {
      *
      * - parameter key: If your objects are contained within dictionary pass the key here
      */
-    public func mapResponse<ResultType: Decodable>(for key: String? = nil) -> Signal<ResultType, Error> where ResultType.DecodedType == ResultType {
+    public func mapResponse<ResultType: Decodable>(forKey key: String? = nil) -> Signal<ResultType, Error> where ResultType.DecodedType == ResultType {
         return attemptMap { data in
             let decoded: Decoded<ResultType> = key.map {
             let dict = data as? [String: Any] ?? [:]
@@ -57,7 +57,7 @@ extension SignalProtocol where Value == Any, Error: DecodeErrorCreatable {
      *
      * - parameter key: If your objects are contained within dictionary pass the key here
      */
-    public func mapResponse<ResultType: Decodable>(for key: String? = nil) -> Signal<[ResultType], Error> where ResultType.DecodedType == ResultType {
+    public func mapResponse<ResultType: Decodable>(forKey key: String? = nil) -> Signal<[ResultType], Error> where ResultType.DecodedType == ResultType {
         return attemptMap { data in
             let decoded: Decoded<[ResultType]> = key.map {
                 let dict = data as? [String: Any] ?? [:]
@@ -81,8 +81,8 @@ extension SignalProducerProtocol where Value == Any, Error: DecodeErrorCreatable
      *
      * - parameter key: If your objects are contained within dictionary pass the key here
      */
-    public func mapResponse<ResultType: Decodable>(for key: String? = nil) -> SignalProducer<ResultType, Error> where ResultType.DecodedType == ResultType {
-        return lift { $0.mapResponse(for: key) }
+    public func mapResponse<ResultType: Decodable>(forKey key: String? = nil) -> SignalProducer<ResultType, Error> where ResultType.DecodedType == ResultType {
+        return lift { $0.mapResponse(forKey: key) }
     }
     
     /**
@@ -90,7 +90,7 @@ extension SignalProducerProtocol where Value == Any, Error: DecodeErrorCreatable
      *
      * - parameter key: If your objects are contained within dictionary pass the key here
      */
-    public func mapResponse<ResultType: Decodable>(for key: String? = nil) -> SignalProducer<[ResultType], Error> where ResultType.DecodedType == ResultType {
-        return lift { $0.mapResponse(for: key) }
+    public func mapResponse<ResultType: Decodable>(forKey key: String? = nil) -> SignalProducer<[ResultType], Error> where ResultType.DecodedType == ResultType {
+        return lift { $0.mapResponse(forKey: key) }
     }
 }

--- a/Docs/Argo.md
+++ b/Docs/Argo.md
@@ -38,12 +38,12 @@ struct Car {
 }
 ```
 
-Now in your API calls you just call `mapResponseArgo()` method and you get what you want.
+Now in your API calls you just call `mapResponse()` method and you get what you want.
 
 ```swift
 func fetchCars() -> SignalProducer<[Car], MyError> {
     let apiCall: SignalProducer<Any, MyError> = ... // make your api call
-    return apiCall.mapResponseArgo()
+    return apiCall.mapResponse()
 }
 ```
 
@@ -53,12 +53,12 @@ That's nicer than using various `map`s and `flatMap`s in your every single call,
 
 ### Use root key
 
-In case your data aren't always root objects of your API response you can use `key` parameter of `mapResponseArgo()` method.
+In case your data aren't always root objects of your API response you can use `key` parameter of `mapResponse()` method.
 
 ```swift
 func fetchCars() -> SignalProducer<[Car], MyError> {
     let apiCall: SignalProducer<Any, MyError> = ... // make your api call
-    return apiCall.mapResponseArgo(for: "data")
+    return apiCall.mapResponse(for: "data")
 }
 ```
 
@@ -71,7 +71,7 @@ Just assume the you are just interested in fetching just manufacturers of all ca
 func fetchManufacturers() -> SignalProducer<[String], MyError> {
     let apiCall: SignalProducer<Any, MyError> = ... // make your api call just like you did before
     return apiCall
-        .mapResponseArgo() // ambiguous use of mapResponseArgo()
+        .mapResponse() // ambiguous use of mapResponse()
         .map { $0.map { $0.manufacturer } }
 }
 ```
@@ -82,7 +82,7 @@ Now you end up with ambiguity. How so? It's simple, now the compiler doesn't kno
 func fetchManufacturers() -> SignalProducer<[String], MyError> {
     let apiCall: SignalProducer<Any, MyError> = ... // make your api call just like you did before
     return apiCall
-        .mapResponseArgo()
+        .mapResponse()
         .map { (cars: [Car]) in
             return cars.map { $0.manufacturer }
         }
@@ -93,7 +93,7 @@ Now you're all set and ready. The same issue arises if you don't return you `Sig
 ```swift
 func fetchCars() -> SignalProducer<[Car], MyError> {
     let apiCall: SignalProducer<Any, MyError> = ... // make your api call
-    let carsProducer: SignalProducer<[Car], MyError> = apiCall.mapResponseArgo()
+    let carsProducer: SignalProducer<[Car], MyError> = apiCall.mapResponse()
     return carsProducer
 }
 ```

--- a/Docs/Argo.md
+++ b/Docs/Argo.md
@@ -58,7 +58,7 @@ In case your data aren't always root objects of your API response you can use `k
 ```swift
 func fetchCars() -> SignalProducer<[Car], MyError> {
     let apiCall: SignalProducer<Any, MyError> = ... // make your api call
-    return apiCall.mapResponse(for: "data")
+    return apiCall.mapResponse(forKey: "data")
 }
 ```
 

--- a/Example/Tests/ArgoMappingTests.swift
+++ b/Example/Tests/ArgoMappingTests.swift
@@ -52,7 +52,7 @@ class ArgoMappingTests: XCTestCase {
         
         // producer completes synchronously
         producer(for: object)
-            .mapResponseArgo()
+            .mapResponse()
             .startWithResult { (result: Result<ModelStub, ErrorStub>) in
                 XCTAssertEqual(result.value, object)
                 XCTAssertNil(result.error)
@@ -65,7 +65,7 @@ class ArgoMappingTests: XCTestCase {
         
         // producer completes synchronously
         producer(for: objects)
-            .mapResponseArgo()
+            .mapResponse()
             .startWithResult { (result: Result<[ModelStub], ErrorStub>) in
                 XCTAssertEqual(result.value!, objects)
                 XCTAssertNil(result.error)
@@ -78,7 +78,7 @@ class ArgoMappingTests: XCTestCase {
         
         // producer completes synchronously
         invalidProducer(for: objects)
-            .mapResponseArgo()
+            .mapResponse()
             .startWithResult { (result: Result<[ModelStub], ErrorStub>) in
                 XCTAssertNil(result.value)
                 XCTAssertNotNil(result.error)
@@ -90,7 +90,7 @@ class ArgoMappingTests: XCTestCase {
         
         // producer completes synchronously
         invalidProducer(for: object)
-            .mapResponseArgo()
+            .mapResponse()
             .startWithResult { (result: Result<ModelStub, ErrorStub>) in
                 XCTAssertNil(result.value)
                 XCTAssertNotNil(result.error)
@@ -103,7 +103,7 @@ class ArgoMappingTests: XCTestCase {
         
         producer(for: object)
             .map { [key: $0] }
-            .mapResponseArgo(for: key)
+            .mapResponse(for: key)
             .startWithResult { (result: Result<ModelStub, ErrorStub>) in
                 XCTAssertEqual(result.value, object)
                 XCTAssertNil(result.error)
@@ -118,7 +118,7 @@ class ArgoMappingTests: XCTestCase {
         // producer completes synchronously
         producer(for: objects)
             .map { [key: $0] }
-            .mapResponseArgo(for: key)
+            .mapResponse(for: key)
             .startWithResult { (result: Result<[ModelStub], ErrorStub>) in
                 XCTAssertEqual(result.value!, objects)
                 XCTAssertNil(result.error)
@@ -131,7 +131,7 @@ class ArgoMappingTests: XCTestCase {
         
         invalidProducer(for: object)
             .map { [key: $0] }
-            .mapResponseArgo(for: key)
+            .mapResponse(for: key)
             .startWithResult { (result: Result<ModelStub, ErrorStub>) in
                 XCTAssertNil(result.value)
                 XCTAssertNotNil(result.error)
@@ -146,7 +146,7 @@ class ArgoMappingTests: XCTestCase {
         // producer completes synchronously
         invalidProducer(for: objects)
             .map { [key: $0] }
-            .mapResponseArgo(for: key)
+            .mapResponse(for: key)
             .startWithResult { (result: Result<[ModelStub], ErrorStub>) in
                 XCTAssertNil(result.value)
                 XCTAssertNotNil(result.error)

--- a/Example/Tests/ArgoMappingTests.swift
+++ b/Example/Tests/ArgoMappingTests.swift
@@ -103,7 +103,7 @@ class ArgoMappingTests: XCTestCase {
         
         producer(for: object)
             .map { [key: $0] }
-            .mapResponse(for: key)
+            .mapResponse(forKey: key)
             .startWithResult { (result: Result<ModelStub, ErrorStub>) in
                 XCTAssertEqual(result.value, object)
                 XCTAssertNil(result.error)
@@ -118,7 +118,7 @@ class ArgoMappingTests: XCTestCase {
         // producer completes synchronously
         producer(for: objects)
             .map { [key: $0] }
-            .mapResponse(for: key)
+            .mapResponse(forKey: key)
             .startWithResult { (result: Result<[ModelStub], ErrorStub>) in
                 XCTAssertEqual(result.value!, objects)
                 XCTAssertNil(result.error)
@@ -131,7 +131,7 @@ class ArgoMappingTests: XCTestCase {
         
         invalidProducer(for: object)
             .map { [key: $0] }
-            .mapResponse(for: key)
+            .mapResponse(forKey: key)
             .startWithResult { (result: Result<ModelStub, ErrorStub>) in
                 XCTAssertNil(result.value)
                 XCTAssertNotNil(result.error)
@@ -146,7 +146,7 @@ class ArgoMappingTests: XCTestCase {
         // producer completes synchronously
         invalidProducer(for: objects)
             .map { [key: $0] }
-            .mapResponse(for: key)
+            .mapResponse(forKey: key)
             .startWithResult { (result: Result<[ModelStub], ErrorStub>) in
                 XCTAssertNil(result.value)
                 XCTAssertNotNil(result.error)


### PR DESCRIPTION
- simplify syntax (rename mapResponseArgo to mapResponse) #4
- make mapResponseArgo deprecated
- fix some compiler warnings in Argo extensions

Please do not release, will do i myself when all the maintenance is finished.