### PR TITLE
Add helper for merging signals/producers

### DIFF
--- a/ACKReactiveExtensions/Core/Core.swift
+++ b/ACKReactiveExtensions/Core/Core.swift
@@ -33,6 +33,14 @@ extension Signal {
             observer.sendInterrupted()
         }
     }
+
+    /// Creates new signal by merging `Self` with other signal.
+    ///
+    /// - Parameter other: Signal to merge `Self` with
+    /// - Returns: New Signal
+    public func merge(with other: Signal<Value, Error>) -> Signal<Value, Error> {
+        return Signal.merge([self, other])
+    }
 }
 
 extension SignalProducer where Value == Void, Error == NoError {
@@ -60,6 +68,14 @@ extension SignalProducer {
             observer.send(value: lazyValue())
             observer.sendCompleted()
         }
+    }
+
+    /// Creates new signal producer by merging `Self` with other producer.
+    ///
+    /// - Parameter other: Producer to merge `Self` with
+    /// - Returns: New SignalProducer
+    public func merge(with other: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
+        return SignalProducer.merge([self, other])
     }
 }
 


### PR DESCRIPTION
Adds simple helper for merging Signals/SignalProducers:

```swift
let a: SignalProducer<Void, NoError> = /* .. */
let b: SignalProducer<Void, NoError> = /* .. */

// Use this:
let c = a.merge(with: b)

// Instead of:
let d = SignalProducer.merge([a, b])
```