### PR TITLE
Remove `signal.merge(with:)`

### DIFF
--- a/ACKReactiveExtensions.xcodeproj/project.pbxproj
+++ b/ACKReactiveExtensions.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		691DCED421105D5300F5C06A /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 699B58F01FF52E2D00FFDC91 /* Result.framework */; };
 		691F8596202A106600DA4FAD /* UIControlExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 691F8595202A106600DA4FAD /* UIControlExtensions.swift */; };
 		6925243F20D14EC300228289 /* UIViewControllerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6925243D20D14E7100228289 /* UIViewControllerExtensions.swift */; };
 		69470C64200763C00013A386 /* ActionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69470C63200763C00013A386 /* ActionExtensions.swift */; };
@@ -195,6 +196,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				691DCED421105D5300F5C06A /* Result.framework in Frameworks */,
 				699B59271FF5437300FFDC91 /* ReactiveSwift.framework in Frameworks */,
 				699B58F91FF52F0E00FFDC91 /* ACKReactiveExtensionsCore.framework in Frameworks */,
 			);

--- a/ACKReactiveExtensions/Core/Core.swift
+++ b/ACKReactiveExtensions/Core/Core.swift
@@ -33,14 +33,6 @@ extension Signal {
             observer.sendInterrupted()
         }
     }
-
-    /// Creates new signal by merging `Self` with other signal.
-    ///
-    /// - Parameter other: Signal to merge `Self` with
-    /// - Returns: New Signal
-    public func merge(with other: Signal<Value, Error>) -> Signal<Value, Error> {
-        return Signal.merge([self, other])
-    }
 }
 
 extension SignalProducer where Value == Void, Error == NoError {


### PR DESCRIPTION
As it is ambigous with `signal.merge(with:)` in _ReactiveSwift 4.0_