### PR TITLE
Deprecate extensions which are available through keypaths

### DIFF
--- a/ACKReactiveExtensions/UIKit/CALayerExtensions.swift
+++ b/ACKReactiveExtensions/UIKit/CALayerExtensions.swift
@@ -10,19 +10,19 @@ import ReactiveSwift
 
 extension Reactive where Base: CALayer {
     /// Binding that represents `borderWidth`
-    @available(*, deprecated, message: "User [\\.borderWidth] instead")
+    @available(*, deprecated, renamed: "[\\.borderWidth]")
     public var borderWidth: BindingTarget<CGFloat> {
         return self[\.borderWidth]
     }
     
     /// Binding that represents `borderColor`
-    @available(*, deprecated, message: "User [\\.borderColor] instead")
+    @available(*, deprecated, renamed: "[\\.borderColor]")
     public var borderColor: BindingTarget<CGColor?> {
         return self[\.borderColor]
     }
     
     /// Binding that represents `cornerRadius`
-    @available(*, deprecated, message: "User [\\.cornerRadius] instead")
+    @available(*, deprecated, renamed: "[\\.cornerRadius]")
     public var cornerRadius: BindingTarget<CGFloat> {
         return self[\.cornerRadius]
     }

--- a/ACKReactiveExtensions/UIKit/CALayerExtensions.swift
+++ b/ACKReactiveExtensions/UIKit/CALayerExtensions.swift
@@ -10,17 +10,20 @@ import ReactiveSwift
 
 extension Reactive where Base: CALayer {
     /// Binding that represents `borderWidth`
+    @available(*, deprecated, message: "User [\\.borderWidth] instead")
     public var borderWidth: BindingTarget<CGFloat> {
-        return makeBindingTarget { $0.borderWidth = $1 }
+        return self[\.borderWidth]
     }
     
     /// Binding that represents `borderColor`
-    public var borderColor: BindingTarget<CGColor> {
-        return makeBindingTarget { $0.borderColor = $1 }
+    @available(*, deprecated, message: "User [\\.borderColor] instead")
+    public var borderColor: BindingTarget<CGColor?> {
+        return self[\.borderColor]
     }
     
     /// Binding that represents `cornerRadius`
+    @available(*, deprecated, message: "User [\\.cornerRadius] instead")
     public var cornerRadius: BindingTarget<CGFloat> {
-        return makeBindingTarget { $0.cornerRadius = $1 }
+        return self[\.cornerRadius]
     }
 }

--- a/ACKReactiveExtensions/UIKit/CALayerExtensions.swift
+++ b/ACKReactiveExtensions/UIKit/CALayerExtensions.swift
@@ -10,19 +10,19 @@ import ReactiveSwift
 
 extension Reactive where Base: CALayer {
     /// Binding that represents `borderWidth`
-    @available(*, deprecated, renamed: "[\\.borderWidth]")
+    @available(*, deprecated, message: "Use [\\.borderWidth] instead")
     public var borderWidth: BindingTarget<CGFloat> {
         return self[\.borderWidth]
     }
     
     /// Binding that represents `borderColor`
-    @available(*, deprecated, renamed: "[\\.borderColor]")
+    @available(*, deprecated, message: "Use [\\.borderColor] instead")
     public var borderColor: BindingTarget<CGColor?> {
         return self[\.borderColor]
     }
     
     /// Binding that represents `cornerRadius`
-    @available(*, deprecated, renamed: "[\\.cornerRadius]")
+    @available(*, deprecated, message: "Use [\\.cornerRadius] instead")
     public var cornerRadius: BindingTarget<CGFloat> {
         return self[\.cornerRadius]
     }

--- a/ACKReactiveExtensions/UIKit/UIImageViewExtensions.swift
+++ b/ACKReactiveExtensions/UIKit/UIImageViewExtensions.swift
@@ -9,7 +9,7 @@ import UIKit
 import ReactiveSwift
 
 extension Reactive where Base: UIImageView {
-    @available(*, deprecated, renamed: "signal(for: \\.image)")
+    @available(*, deprecated, message: "signal(for: \\.image)")
     public var imageSignal: Signal<UIImage?, Never> {
         return signal(for: \.image)
     }

--- a/ACKReactiveExtensions/UIKit/UIImageViewExtensions.swift
+++ b/ACKReactiveExtensions/UIKit/UIImageViewExtensions.swift
@@ -9,7 +9,8 @@ import UIKit
 import ReactiveSwift
 
 extension Reactive where Base: UIImageView {
+    @available(*, deprecated, message: "User signal(for: \\.image) instead")
     public var imageSignal: Signal<UIImage?, Never> {
-        return signal(forKeyPath: "image").map { $0 as? UIImage }
+        return signal(for: \.image)
     }
 }

--- a/ACKReactiveExtensions/UIKit/UIImageViewExtensions.swift
+++ b/ACKReactiveExtensions/UIKit/UIImageViewExtensions.swift
@@ -9,7 +9,7 @@ import UIKit
 import ReactiveSwift
 
 extension Reactive where Base: UIImageView {
-    @available(*, deprecated, message: "User signal(for: \\.image) instead")
+    @available(*, deprecated, renamed: "signal(for: \\.image)")
     public var imageSignal: Signal<UIImage?, Never> {
         return signal(for: \.image)
     }

--- a/ACKReactiveExtensions/UIKit/UITableViewExtensions.swift
+++ b/ACKReactiveExtensions/UIKit/UITableViewExtensions.swift
@@ -10,13 +10,13 @@ import ReactiveSwift
 
 extension Reactive where Base: UITableView {
     /// Reactively set `tableHeaderView`
-    @available(*, deprecated, renamed: "[\\.tableHeaderView]")
+    @available(*, deprecated, message: "Use [\\.tableHeaderView] instead")
     public var tableHeaderView: BindingTarget<UIView?> {
         return self[\.tableHeaderView]
     }
     
     /// Reactively set `tableFooterView`
-    @available(*, deprecated, renamed: "[\\.tableFooterView]")
+    @available(*, deprecated, message: "Use [\\.tableFooterView] instead")
     public var tableFooterView: BindingTarget<UIView?> {
         return self[\.tableFooterView]
     }

--- a/ACKReactiveExtensions/UIKit/UITableViewExtensions.swift
+++ b/ACKReactiveExtensions/UIKit/UITableViewExtensions.swift
@@ -9,14 +9,15 @@ import UIKit
 import ReactiveSwift
 
 extension Reactive where Base: UITableView {
-    
     /// Reactively set `tableHeaderView`
+    @available(*, deprecated, message: "User [\\.tableHeaderView] instead")
     public var tableHeaderView: BindingTarget<UIView?> {
-        return makeBindingTarget { $0.tableHeaderView = $1 }
+        return self[\.tableHeaderView]
     }
     
     /// Reactively set `tableFooterView`
+    @available(*, deprecated, message: "User [\\.tableFooterView] instead")
     public var tableFooterView: BindingTarget<UIView?> {
-        return makeBindingTarget { $0.tableFooterView = $1 }
+        return self[\.tableFooterView]
     }
 }

--- a/ACKReactiveExtensions/UIKit/UITableViewExtensions.swift
+++ b/ACKReactiveExtensions/UIKit/UITableViewExtensions.swift
@@ -10,13 +10,13 @@ import ReactiveSwift
 
 extension Reactive where Base: UITableView {
     /// Reactively set `tableHeaderView`
-    @available(*, deprecated, message: "User [\\.tableHeaderView] instead")
+    @available(*, deprecated, renamed: "[\\.tableHeaderView]")
     public var tableHeaderView: BindingTarget<UIView?> {
         return self[\.tableHeaderView]
     }
     
     /// Reactively set `tableFooterView`
-    @available(*, deprecated, message: "User [\\.tableFooterView] instead")
+    @available(*, deprecated, renamed: "[\\.tableFooterView]")
     public var tableFooterView: BindingTarget<UIView?> {
         return self[\.tableFooterView]
     }

--- a/ACKReactiveExtensions/UIKit/UITextFieldExtensions.swift
+++ b/ACKReactiveExtensions/UIKit/UITextFieldExtensions.swift
@@ -10,7 +10,7 @@ import ReactiveSwift
 
 extension Reactive where Base: UITextField {
     /// Binding that represents `textColor`
-    @available(*, deprecated, renamed: "[\\.textColor]")
+    @available(*, deprecated, message: "Use [\\.textColor] instead")
     public var textColor: BindingTarget<UIColor?> {
         return self[\.textColor]
     }

--- a/ACKReactiveExtensions/UIKit/UITextFieldExtensions.swift
+++ b/ACKReactiveExtensions/UIKit/UITextFieldExtensions.swift
@@ -10,8 +10,9 @@ import ReactiveSwift
 
 extension Reactive where Base: UITextField {
     /// Binding that represents `textColor`
+    @available(*, deprecated, message: "User [\\.textColor] instead")
     public var textColor: BindingTarget<UIColor?> {
-        return makeBindingTarget { $0.textColor = $1 }
+        return self[\.textColor]
     }
     
     /**

--- a/ACKReactiveExtensions/UIKit/UITextFieldExtensions.swift
+++ b/ACKReactiveExtensions/UIKit/UITextFieldExtensions.swift
@@ -10,7 +10,7 @@ import ReactiveSwift
 
 extension Reactive where Base: UITextField {
     /// Binding that represents `textColor`
-    @available(*, deprecated, message: "User [\\.textColor] instead")
+    @available(*, deprecated, renamed: "[\\.textColor]")
     public var textColor: BindingTarget<UIColor?> {
         return self[\.textColor]
     }

--- a/ACKReactiveExtensions/UIKit/UIViewExtensions.swift
+++ b/ACKReactiveExtensions/UIKit/UIViewExtensions.swift
@@ -15,7 +15,7 @@ extension Reactive where Base: UIView {
     }
     
     /// Reactively set `transform`
-    @available(*, deprecated, message: "User [\\.transform] instead")
+    @available(*, deprecated, renamed: "[\\.transform]")
     public var transform: BindingTarget<CGAffineTransform> {
         return self[\.transform]
     }

--- a/ACKReactiveExtensions/UIKit/UIViewExtensions.swift
+++ b/ACKReactiveExtensions/UIKit/UIViewExtensions.swift
@@ -15,7 +15,7 @@ extension Reactive where Base: UIView {
     }
     
     /// Reactively set `transform`
-    @available(*, deprecated, renamed: "[\\.transform]")
+    @available(*, deprecated, message: "Use [\\.transform] instead")
     public var transform: BindingTarget<CGAffineTransform> {
         return self[\.transform]
     }

--- a/ACKReactiveExtensions/UIKit/UIViewExtensions.swift
+++ b/ACKReactiveExtensions/UIKit/UIViewExtensions.swift
@@ -11,16 +11,13 @@ import ReactiveSwift
 extension Reactive where Base: UIView {
     /// Property that represents `isHidden`
     public var isHiddenProperty: Property<Bool> {
-        return Property(initial: base.isHidden, then: isHiddenSignal)
-    }
-    
-    private var isHiddenSignal: Signal<Bool, Never> {
-        return signal(forKeyPath: "hidden").map { $0 as? Bool }.skipNil()
+        return Property(initial: base.isHidden, then: signal(for: \.isHidden))
     }
     
     /// Reactively set `transform`
+    @available(*, deprecated, message: "User [\\.transform] instead")
     public var transform: BindingTarget<CGAffineTransform> {
-        return makeBindingTarget { $0.transform = $1 }
+        return self[\.transform]
     }
     
     /// End editing reactively
@@ -32,19 +29,11 @@ extension Reactive where Base: UIView {
     
     /// Property that represents `frame`
     public var frame: Property<CGRect> {
-        return Property(initial: base.frame, then: frameSignal)
+        return Property(initial: base.frame, then: signal(for: \.frame))
     }
     
     /// Property that represents `bounds`
     public var bounds: Property<CGRect> {
-        return Property(initial: base.bounds, then: boundsSignal)
-    }
-    
-    private var frameSignal: Signal<CGRect, Never> {
-        return signal(forKeyPath: "frame").filterMap { $0 as? CGRect }
-    }
-    
-    private var boundsSignal: Signal<CGRect, Never> {
-        return signal(forKeyPath: "bounds").filterMap { $0 as? CGRect }
+        return Property(initial: base.bounds, then: signal(for: \.bounds))
     }
 }

--- a/ACKReactiveExtensions/WebKit/WKWebViewExtensions.swift
+++ b/ACKReactiveExtensions/WebKit/WKWebViewExtensions.swift
@@ -4,12 +4,12 @@ import ReactiveCocoa
 
 extension Reactive where Base: WKWebView {
     /// Property which observes `estimatedProgress` of webView
-    public var estimatedProgress: Property<CGFloat> {
-        return Property(initial: CGFloat(base.estimatedProgress), then: signal(forKeyPath: "estimatedProgress").map { $0 as? CGFloat ?? 0 })
+    public var estimatedProgress: Property<Double> {
+        return Property(initial: base.estimatedProgress, then: signal(for: \.estimatedProgress))
     }
     
     /// Property which observes `isLoading` of webView
     public var isLoading: Property<Bool> {
-        return Property(initial: base.isLoading, then: signal(forKeyPath: "loading").filterMap { $0 as? Bool })
+        return Property(initial: base.isLoading, then: signal(for: \.isLoading))
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## master
 
 - update ReactiveSwift & ReactiveCocoa, use native Result (#41, kudos to @olejnjak)
+- deprecate extensions which are available using Swift typed keypaths #40 (#42, kudos to @olejnjak)
 
 ## 4.1
 


### PR DESCRIPTION
This PR addresses #40. It adds deprecations to extensions which are available through keypaths so they can be removed in later releases. 

Right now I am not sure about the deprecation style - maybe this way would be better?
```
@available(*, deprecated, message: "Use [\.tableHeaderView] instead")
```

#### Checklist
- [x] Updated CHANGELOG.md.