### PR TITLE
Fix RealmCollection bug

### DIFF
--- a/ACKReactiveExtensions/Realm/RealmExtensions.swift
+++ b/ACKReactiveExtensions/Realm/RealmExtensions.swift
@@ -107,7 +107,7 @@ public extension Reactive where Base: RealmCollection {
     
     /// Property which represents the latest value
     var property: ReactiveSwift.Property<Base> {
-        return ReactiveSwift.Property(initial: self.base, then: values.ignoreError().skip(first: 1) )
+        return ReactiveSwift.Property(initial: base, then: values.ignoreError() )
     }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## master
 
+- fix `RealmCollection` bug in case when Realm data is modified before it sends initial change notification (#43, kudos to @olejnjak)
+
 ## 5.0
 
 - update ReactiveSwift & ReactiveCocoa, use native Result (#41, kudos to @olejnjak)


### PR DESCRIPTION
Ocassionally if Realm receives new data before sending initial change notification, it just sends initial notification with modified content (e.g. if data is saved on other thread). So the `skip(first: 1)` would actually skip a change.

#### Checklist
- [ ] Updated CHANGELOG.md.