### PR TITLE
Fix threading for `RealmCollection` observing

### DIFF
--- a/ACKReactiveExtensions/Realm/RealmExtensions.swift
+++ b/ACKReactiveExtensions/Realm/RealmExtensions.swift
@@ -34,9 +34,6 @@ public enum Change<T> {
     case update(T, deletions: [Int], insertions: [Int], modifications: [Int])
 }
 
-/// Custom queue used for `RealmCollection` observing
-private var realmCollectionQueue = DispatchQueue(label: "RealmCollectionQueue")
-
 public extension Reactive where Base: RealmCollection {
 
     /// SignalProducer that sends changes as they happen
@@ -50,7 +47,7 @@ public extension Reactive where Base: RealmCollection {
             }
 
             func observe() -> NotificationToken? {
-                return self.base.observe(on: realmCollectionQueue) { changes in
+                return self.base.observe(on: OperationQueue.current?.underlyingQueue) { changes in
                     switch changes {
                     case .initial(let initial):
                         sink.send(value: Change.initial(initial))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## master
 
-- use custom queue for `RealmCollection` observing (#56, kudos to @IgorRosocha)
+- use non-nil queue for `RealmCollection` observing (#56, kudos to @IgorRosocha + #57, kudos to @olejnjak)
 
 ## 5.3.1
 


### PR DESCRIPTION
Using completely custom queue was not really correct as `RealmCollection` changes were propagated on incorrect thread. This solution tries to use current queue, instead of nil queue, so it should probably fix issue from #56 and also preserve correct thread.

Please @LukasHromadnik run it on your Mac and if it is fine, then we can merge it.