### PR TITLE
🔥 Remove default JSONDecoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## main
 
+- remove default `JSONDecoder` for decode extension (#65, kudos to @olejnjak)
+
 ## 7.0.0
 
 - use single ACKReactiveExtensions target (#63, kudos to @olejnjak)

--- a/Sources/ACKReactiveExtensions/Core/ACKReactiveExtensionsConfiguration.swift
+++ b/Sources/ACKReactiveExtensions/Core/ACKReactiveExtensionsConfiguration.swift
@@ -3,9 +3,6 @@ import Foundation
 /// Configuration for **ACKReactiveExtensions**
 public enum ACKReactiveExtensionsConfiguration {
 
-    /// If `true`, *Marshal* and *Codable* extensions use assert that checks if mapping is done in background
+    /// If `true`, *Codable* extensions use assert that checks if mapping is done in background
     public static var allowMappingOnMainThread = true
-
-    /// Default decoder that is used for *Codable* extensions
-    public static var jsonDecoder = JSONDecoder()
 }

--- a/Sources/ACKReactiveExtensions/Core/Codable.swift
+++ b/Sources/ACKReactiveExtensions/Core/Codable.swift
@@ -18,7 +18,7 @@ public extension SignalProducer where Value == Data, Error: DecodingErrorCreatab
     /// Decodes given `type` from received data using given `decoder`
     ///
     /// By default the `type` is inferred from return value
-    func decode<ResultType: Decodable>(type: ResultType.Type = ResultType.self, using decoder: JSONDecoder = ACKReactiveExtensionsConfiguration.jsonDecoder) -> SignalProducer<ResultType, Error> {
+    func decode<ResultType: Decodable>(type: ResultType.Type = ResultType.self, using decoder: JSONDecoder) -> SignalProducer<ResultType, Error> {
         lift { $0.decode(type: type, using: decoder) }
     }
 }
@@ -27,7 +27,7 @@ public extension Signal where Value == Data, Error: DecodingErrorCreatable {
     /// Decodes given `type` from received data using given `decoder`
     ///
     /// By default the `type` is inferred from return value, if no `decoder` is provided then `ACKReactiveExtensionsConfiguration.jsonDecoder` is used
-    func decode<ResultType: Decodable>(type: ResultType.Type = ResultType.self, using decoder: JSONDecoder = ACKReactiveExtensionsConfiguration.jsonDecoder) -> Signal<ResultType, Error> {
+    func decode<ResultType: Decodable>(type: ResultType.Type = ResultType.self, using decoder: JSONDecoder) -> Signal<ResultType, Error> {
         attemptMap { data -> Result<ResultType, Error> in
             if ACKReactiveExtensionsConfiguration.allowMappingOnMainThread == false {
                 assert(Thread.current.isMainThread == false, "Mapping should not be performed on main thread!")


### PR DESCRIPTION
Makes more harm than use as it leads to inconsistent decoders throughout apps.